### PR TITLE
Adding option to enable caching telemetry when being offline

### DIFF
--- a/Scripts/typings/async/async.d.ts
+++ b/Scripts/typings/async/async.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+interface AsyncAction<T> { (callback:AsyncSingleResultCallback<T>):void }
 interface AsyncMultipleResultsCallback<T> { (err: Error, results: T[]): any; }
 interface AsyncSingleResultCallback<T> { (err: Error, result: T): void; }
 interface AsyncTimesCallback<T> { (n: number, callback: AsyncMultipleResultsCallback<T>): void; }
@@ -78,6 +79,7 @@ interface Async {
     concatSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R[]>, callback: AsyncMultipleResultsCallback<R>): any;
 
     // Control Flow
+    series<T>(tasks: AsyncAction<T>[], callback?: AsyncMultipleResultsCallback<T>): void;
     series<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;
     series<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
     parallel<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;

--- a/Sender.ts
+++ b/Sender.ts
@@ -3,18 +3,29 @@
 * uses the batching logic in Javascript Sender.send but sends with node http.request
 */
 class Sender {
+    
+    public static TEMPDIR: string = 'appInsights-node'; 
+    
     private _config: Microsoft.ApplicationInsights.ISenderConfig;
     private _onSuccess: (response: string) => void;
     private _onError: (error: Error) => void;
+    private _enableCacheOnError: boolean; 
     private _http;
     private _url;
+    private _os; 
+    private _path; 
+    private _fs; 
 
     constructor(config: Microsoft.ApplicationInsights.ISenderConfig, onSuccess?: (response: string) => void, onError?: (error: Error) => void) {
         this._config = config;
         this._onSuccess = onSuccess;
         this._onError = onError;
+        this._enableCacheOnError = false;
         this._http = require("http");
         this._url = require("url");
+        this._os = require('os'); 
+        this._path = require('path');
+        this._fs = require('fs'); 
     }
 
     public send(payload: string) {
@@ -48,17 +59,112 @@ class Sender {
                 if (typeof this._onSuccess === "function") {
                     this._onSuccess(responseString);
                 }
+                
+                if (this._enableCacheOnError) {
+                    // try to send any cached events if the user is back online
+                    if (res.statusCode === 200) {
+                        this._sendFirstFileOnDisk();
+                    } else {
+                        // cache the payload to send it later
+                        this._storeToDisk(payload);
+                    }
+                }
             });
         });
 
         req.on('error', (error) => {
-            if (typeof this._onError === "function") {
-                this._onError(error);
+            this._onErrorHelper(error); 
+
+            if (this._enableCacheOnError){
+                this._storeToDisk(payload);
             }
         });
 
         req.write(payload);
         req.end();
+    }
+    
+    /**
+     * enable caching events locally on error
+     */
+    public enableCacheOnError(): void {
+        this._enableCacheOnError = true;
+    }
+    
+    /**
+    * disable caching events locally on error
+    */
+    public disableCacheOnError(): void {
+        this._enableCacheOnError = false;
+    }
+    
+    /**
+     * Stores the payload as a json file on disk in the temp direcotry
+     */
+    private _storeToDisk(payload: string) {
+        
+        //ensure directory is created
+        var direcotry = this._path.join(this._os.tmpDir(), Sender.TEMPDIR);
+        if (!this._fs.existsSync(direcotry)) {
+            try {
+                this._fs.mkdirSync(direcotry);
+            } catch (error) {
+                // failing to create the temp direcotry 
+                this._onErrorHelper(error);
+                return;
+            }
+        }
+        
+        //create file - file name for now is the timestamp, a better approach would be a UUID but that
+        //would require an external dependency 
+        var fileName = new Date().getTime() + '.json';
+        var fileFullPath = this._path.join(direcotry, fileName);
+        
+        // if the file already exist, replace the content
+        this._fs.writeFile(fileFullPath, payload,(error) => this._onErrorHelper(error));
+    }
+    
+    /**
+     * Check for temp telemetry files
+     * reads the first file if exist, deletes it and tries to send its load
+     */
+    private _sendFirstFileOnDisk(): void {
+        var tempDir = this._path.join(this._os.tmpDir(), Sender.TEMPDIR);
+        
+        if (!this._fs.existsSync(tempDir)) {
+            return; 
+        }
+        
+        this._fs.readdir(tempDir,(error, files) => {
+            if (!error) {
+                if (files.length > 0) {
+                    var firstFile = files[0];
+                    var filePath = this._path.join(tempDir, firstFile);
+                    this._fs.readFile(filePath,(error, payload) => {
+                        if (!error) {
+                            // delete the file first to prevent double sending
+                            this._fs.unlink(filePath,(error) => {
+                                if (!error) {
+                                    this.send(payload);
+                                } else {
+                                    this._onErrorHelper(error);
+                                }
+                            });
+                        } else {
+                            this._onErrorHelper(error);
+                        }
+                    });
+                }
+            } else {
+                this._onErrorHelper(error);
+            }
+        });
+    }
+
+    private _onErrorHelper(error: Error): void {
+        if (typeof this._onError === "function") {
+            this._onError(error);
+        }
     }
 }
 

--- a/Tests/TestHelper.ts
+++ b/Tests/TestHelper.ts
@@ -5,7 +5,7 @@ import async = require("async");
 class TestHelper {
     public results;
     public isSuccessfulTestRun;
-    private tests: Array<(any, TestResult) => void>;
+    private tests: Array<AsyncAction<TestHelper.TestResult>>;
 
     constructor() {
         this.isSuccessfulTestRun = true;

--- a/applicationInsights.ts
+++ b/applicationInsights.ts
@@ -22,6 +22,7 @@ class AppInsights extends ai.AppInsights {
     private _requestListener;
     private _originalServer;
     private _exceptionListenerHandle;
+    private _enableCacheOnError: boolean; 
 
     constructor(config?: AppInsights.IConfig) {
         // ensure we have an instrumentationKey
@@ -56,6 +57,8 @@ class AppInsights extends ai.AppInsights {
             diagnosticLogInterval: config.diagnosticLogInterval || 10000,
             autoCollectErrors: false
         };
+        
+        this._enableCacheOnError = !!config.enableCacheOnError;  
 
         // initialize base class
         super(this.config);
@@ -77,6 +80,9 @@ class AppInsights extends ai.AppInsights {
         var Sender = require("./Sender");
         var browserSender = this.context._sender;
         var sender: Sender = new Sender(browserSender._config);
+        if (this._enableCacheOnError) {
+            sender.enableCacheOnError(); 
+        }
         browserSender._sender = (payload: string) => sender.send(payload);
     }
 
@@ -309,6 +315,7 @@ module AppInsights {
         disableTelemetry?: boolean;
         verboseLogging?: boolean;
         diagnosticLogInterval?: number;
+        enableCacheOnError?: boolean;
     }
     
     // For compatibility with existing code, continue to


### PR DESCRIPTION
For Node.js application that expect intermittent internet connection, this change enables the App Insights SDK to be tolerant to the user being offline. When this option is enabled, the SDK caches the events in the tmp directory and upon the next successful post, it retries to submit all the data that occured while being offline. 

This change contains: 
1- A fix to some typescript definition files. npm test is not working due to some type mismatch. 
2- Adding cacheOnError config option support and adding the appropriate E2E tests. 
